### PR TITLE
Make goo_format::header::ExposureDelayMode public

### DIFF
--- a/goo_format/src/lib.rs
+++ b/goo_format/src/lib.rs
@@ -9,7 +9,7 @@ mod preview_image;
 
 pub use encoded_layer::{LayerDecoder, LayerEncoder};
 pub use file::File;
-pub use header::Header;
+pub use header::{ExposureDelayMode, Header};
 pub use layer_content::LayerContent;
 pub use preview_image::PreviewImage;
 


### PR DESCRIPTION
This makes it possible to use the `goo_format` crate outside of the project.