### PR TITLE
Add per-model relative exposure configuration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Use standard unit (mm/min) for lift/retract speeds and slice height ([#22](https://github.com/connorslade/mslicer/issues/22))
 - Replace about panel with a first time popup that links to the documentation
 - Show individual model volume (before slicing)
+- Model specific relative exposures
 
 ## v0.5.0 &mdash; February 21st, 2026
 

--- a/mslicer/src/app/history.rs
+++ b/mslicer/src/app/history.rs
@@ -28,7 +28,7 @@ pub enum ModelAction {
     Position(Vector3<f32>),
     Scale(Vector3<f32>),
     Rotation(Vector3<f32>),
-    RelativeExposure(f32),
+    RelativeExposure(u8),
 }
 
 impl History {
@@ -116,7 +116,7 @@ impl ModelAction {
                 ModelAction::Rotation(old)
             }
             ModelAction::RelativeExposure(exposure) => {
-                ModelAction::RelativeExposure(mem::replace(&mut model.relative_exposure, exposure))
+                ModelAction::RelativeExposure(mem::replace(&mut model.exposure, exposure))
             }
         })
     }

--- a/mslicer/src/app/mod.rs
+++ b/mslicer/src/app/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     windows::{self, Tab},
 };
 use common::{progress::CombinedProgress, units::Milimeter};
-use slicer::slicer::Slicer;
+use slicer::slicer::{Slicer, SlicerModel};
 
 pub mod config;
 pub mod history;
@@ -143,21 +143,18 @@ impl App {
 
         // Transform models from world-space to platform-space
         let mut out = Vec::new();
-        let mut exposures = Vec::new();
-
         for model in meshes.into_iter() {
-            let mut mesh = model.mesh;
-            mesh.set_scale_unchecked(mesh.scale().component_mul(&mm_to_px));
+            let (mut mesh, exposure) = (model.mesh, model.exposure);
 
             let offset = (platform / 2.0).push(-slice_height / 2.0);
+            mesh.set_scale_unchecked(mesh.scale().component_mul(&mm_to_px));
             mesh.set_position_unchecked(mesh.position().component_mul(&mm_to_px) + offset);
             mesh.update_transformation_matrix();
 
-            out.push(mesh);
-            exposures.push((model.relative_exposure * 255.0) as u8);
+            out.push(SlicerModel { mesh, exposure });
         }
 
-        let slicer = Slicer::new_with_exposures(slice_config, out, exposures);
+        let slicer = Slicer::new(slice_config, out);
         let post_process = CombinedProgress::new();
         let slice_operation = SliceOperation::new(slicer.progress(), post_process.clone());
         self.slice_operation.replace(slice_operation);

--- a/mslicer/src/app/project/model.rs
+++ b/mslicer/src/app/project/model.rs
@@ -34,10 +34,9 @@ pub struct Model {
     pub overhangs: Option<Vec<u32>>,
 
     pub color: LinearRgb<f32>,
+    pub exposure: u8,
     pub hidden: bool,
     pub ui: ModelUi,
-
-    pub relative_exposure: f32,
 
     buffers: Option<RenderedMeshBuffers>,
 }
@@ -84,9 +83,8 @@ impl Model {
 
             color: LinearRgb::repeat(1.0),
             hidden: false,
+            exposure: 255,
             ui: ModelUi::default(),
-
-            relative_exposure: 1.0,
 
             buffers: None,
         }
@@ -104,6 +102,11 @@ impl Model {
 
     pub fn with_color(mut self, color: LinearRgb<f32>) -> Self {
         self.color = color;
+        self
+    }
+
+    pub fn with_exposure(mut self, exposure: u8) -> Self {
+        self.exposure = exposure;
         self
     }
 
@@ -203,7 +206,7 @@ impl Clone for Model {
             hidden: self.hidden,
             ui: self.ui.clone(),
 
-            relative_exposure: self.relative_exposure,
+            exposure: self.exposure,
 
             buffers: None,
         }

--- a/mslicer/src/app/project/storage.rs
+++ b/mslicer/src/app/project/storage.rs
@@ -17,18 +17,22 @@ use slicer::{
 /// Project format version. Value should be incremented whenever the save format
 /// changes, even in development.
 ///
+/// ## v4
+/// Added relative exposure value to models.
+///
 /// ## v3
 /// Added the PWM value to SliceConfig -> ExposureConfig.
 ///
 /// ## v2
 /// A complete rewrite using a custom serilizer/deserilizer because of the bincode drama...
-const VERSION: u16 = 3;
+const VERSION: u16 = 4;
 
 struct ModelInfo {
     mesh: u32,
 
     name: String,
     color: Vector3<f32>,
+    exposure: u8,
     hidden: bool,
 
     position: Vector3<f32>,
@@ -42,6 +46,7 @@ impl ModelInfo {
             mesh,
             name: model.name.to_owned(),
             color: model.color.into(),
+            exposure: model.exposure,
             hidden: model.hidden,
             position: model.mesh.position(),
             scale: model.mesh.scale(),
@@ -59,6 +64,7 @@ impl ModelInfo {
         Model::from_mesh(mesh)
             .with_name(self.name)
             .with_color(self.color.into())
+            .with_exposure(self.exposure)
             .with_hidden(self.hidden)
     }
 
@@ -70,6 +76,7 @@ impl ModelInfo {
         ser.write_u32_be(self.name.len() as u32);
         ser.write_bytes(self.name.as_bytes());
         Vector3::from(self.color).serialize(ser);
+        ser.write_u8(self.exposure);
         ser.write_bool(self.hidden);
 
         // Mesh properties
@@ -78,7 +85,7 @@ impl ModelInfo {
         self.rotation.serialize(ser);
     }
 
-    pub fn deserialize<T: Deserializer>(des: &mut T) -> Self {
+    pub fn deserialize<T: Deserializer>(des: &mut T, version: u16) -> Self {
         Self {
             mesh: des.read_u32_be(),
             name: {
@@ -87,6 +94,7 @@ impl ModelInfo {
                 String::from_utf8_lossy(&data).into_owned()
             },
             color: Vector3::<f32>::deserialize(des),
+            exposure: if version < 4 { 255 } else { des.read_u8() },
             hidden: des.read_bool(),
             position: Vector3::<f32>::deserialize(des),
             scale: Vector3::<f32>::deserialize(des),
@@ -141,7 +149,7 @@ impl Project {
 
         let models = des.read_u32_be();
         let models = (0..models)
-            .map(|_| ModelInfo::deserialize(des))
+            .map(|_| ModelInfo::deserialize(des, version))
             .collect::<Vec<_>>();
 
         let meshes = des.read_u32_be();

--- a/mslicer/src/windows/models.rs
+++ b/mslicer/src/windows/models.rs
@@ -268,21 +268,20 @@ fn model_properties(app: &mut App, ui: &mut Ui, ctx: &Context, action: &mut Acti
             ui.end_row();
 
             ui.label("Relative Exposure");
-            let mut value = model.relative_exposure * 100.0;
+            let mut value = model.exposure as f32 / 2.55;
             let editing = being_edited(
                 &DragValue::new(&mut value)
                     .range(0.0..=100.0)
+                    .max_decimals(0)
                     .suffix("%")
                     .ui(ui),
             );
 
             history_tracked_model(
                 (editing, ui, &mut app.history),
-                (id, || {
-                    ModelAction::RelativeExposure(model.relative_exposure)
-                }),
+                (id, || ModelAction::RelativeExposure(model.exposure)),
             );
-            editing.then(|| model.relative_exposure = value / 100.0);
+            editing.then(|| model.exposure = (value * 2.55).round() as u8);
 
             ui.end_row();
         });

--- a/mslicer/src/windows/slice_config.rs
+++ b/mslicer/src/windows/slice_config.rs
@@ -183,7 +183,7 @@ fn exposure_config(ui: &mut Ui, config: &mut ExposureConfig) {
             row.col(|ui| {
                 let mut pwm = config.pwm as f32 / 2.55;
                 DragValue::new(&mut pwm).max_decimals(0).suffix('%').ui(ui);
-                config.pwm = (pwm * 2.55) as u8;
+                config.pwm = (pwm * 2.55).round() as u8;
             });
         })
         .body(|mut body| {

--- a/slicer/bin/main.rs
+++ b/slicer/bin/main.rs
@@ -17,7 +17,10 @@ use common::{
     slice::SliceConfig,
     units::Milimeter,
 };
-use slicer::{mesh::Mesh, slicer::Slicer};
+use slicer::{
+    mesh::Mesh,
+    slicer::{Slicer, SlicerModel},
+};
 
 mod args;
 
@@ -62,7 +65,10 @@ fn main() -> Result<()> {
             println!(" \\ Model extends outsize of print volume and will be cut off.",);
         }
 
-        meshes.push(mesh);
+        meshes.push(SlicerModel {
+            mesh,
+            exposure: 255,
+        });
     }
 
     let slicer = Slicer::new(slice_config.clone(), meshes);

--- a/slicer/src/slicer/mod.rs
+++ b/slicer/src/slicer/mod.rs
@@ -13,30 +13,23 @@ const SEGMENT_LAYERS: usize = 100;
 /// Used to slice a mesh.
 pub struct Slicer {
     slice_config: SliceConfig,
-    models: Vec<Mesh>,
-
-    exposures: Vec<u8>,
+    models: Vec<SlicerModel>,
 
     layers: u32,
     progress: Progress,
 }
 
-impl Slicer {
-    /// Creates a new slicer given a slice config and list of models.
-    pub fn new(slice_config: SliceConfig, models: Vec<Mesh>) -> Self {
-        let exposures = vec![255; models.len()];
-        Self::new_with_exposures(slice_config, models, exposures)
-    }
+pub struct SlicerModel {
+    pub mesh: Mesh,
+    pub exposure: u8,
+}
 
+impl Slicer {
     /// Creates a new slicer given a slice config, list of models, and their relative exposures.
-    pub fn new_with_exposures(
-        slice_config: SliceConfig,
-        models: Vec<Mesh>,
-        exposures: Vec<u8>,
-    ) -> Self {
+    pub fn new(slice_config: SliceConfig, models: Vec<SlicerModel>) -> Self {
         let max_z = models.iter().fold(0_f32, |max, model| {
-            let verts = model.vertices().iter();
-            let z = verts.fold(0_f32, |max, &f| max.max(model.transform(&f).z));
+            let verts = model.mesh.vertices().iter();
+            let z = verts.fold(0_f32, |max, &f| max.max(model.mesh.transform(&f).z));
             max.max(z)
         });
 
@@ -50,8 +43,6 @@ impl Slicer {
         Self {
             slice_config,
             models,
-
-            exposures,
 
             layers,
             progress,

--- a/slicer/src/slicer/slice_raster.rs
+++ b/slicer/src/slicer/slice_raster.rs
@@ -24,7 +24,7 @@ impl Slicer {
         // to find all intersections. This massively speeds up the slicing
         // operation and actually makes it faster than most other slicers. :p
         let segments = (self.models.iter())
-            .map(|x| Segments1D::from_mesh(x, SEGMENT_LAYERS))
+            .map(|model| Segments1D::from_mesh(&model.mesh, SEGMENT_LAYERS))
             .collect::<Vec<_>>();
 
         let layers = (0..self.layers)
@@ -37,12 +37,9 @@ impl Slicer {
                 // intersection will return two points. These can then be
                 // interpreted as line segments making up a polygon.
                 let segments = (self.models.iter().enumerate())
-                    .flat_map(|(idx, mesh)| {
-                        let exposure = self.exposures[idx];
-                        segments[idx]
-                            .intersect_plane(mesh, height)
-                            .into_iter()
-                            .map(move |segment| (segment, exposure))
+                    .flat_map(|(idx, model)| {
+                        let intersections = segments[idx].intersect_plane(&model.mesh, height);
+                        (intersections.into_iter()).map(|segment| (segment, model.exposure))
                     })
                     .collect::<Vec<_>>();
 
@@ -94,9 +91,8 @@ impl Slicer {
                             let (start, length) = (a + y_offset, b - a);
                             (start > last).then(|| encoder.add_run(start - last, 0));
 
-                            let max_exposure =
-                                exposures.iter().rposition(|&x| x > 0).unwrap_or(255);
-                            encoder.add_run(length, max_exposure as u8);
+                            let exposure = exposures.iter().rposition(|&x| x > 0).unwrap_or(255);
+                            encoder.add_run(length, exposure as u8);
 
                             voxels.fetch_add(length, Ordering::Relaxed);
                             last = start + length;

--- a/slicer/src/slicer/slice_vector.rs
+++ b/slicer/src/slicer/slice_vector.rs
@@ -27,10 +27,8 @@ pub struct SvgFile {
 
 impl Slicer {
     pub fn slice_vector(&self) -> VectorSliceResult<'_> {
-        let segments = self
-            .models
-            .iter()
-            .map(|x| Segments1D::from_mesh(x, SEGMENT_LAYERS))
+        let segments = (self.models.iter())
+            .map(|x| Segments1D::from_mesh(&x.mesh, SEGMENT_LAYERS))
             .collect::<Vec<_>>();
 
         let layers = (0..self.layers)
@@ -39,11 +37,8 @@ impl Slicer {
             .map(|layer| {
                 let height = layer as f32 * self.slice_config.slice_height.get::<Milimeter>();
 
-                let segments = self
-                    .models
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(idx, mesh)| segments[idx].intersect_plane(mesh, height))
+                let segments = (self.models.iter().enumerate())
+                    .flat_map(|(idx, model)| segments[idx].intersect_plane(&model.mesh, height))
                     .flat_map(|x| x.0)
                     .map(|x| x.xy())
                     .collect::<Vec<_>>();


### PR DESCRIPTION
This allows varying the exposure between 0-100%, and makes it a lot easier to test different exposures at the same time.

Model intersections aren't handled properly yet, not sure how to do that..