### PR TITLE
Add model reload button

### DIFF
--- a/mslicer/src/app/project/model.rs
+++ b/mslicer/src/app/project/model.rs
@@ -135,6 +135,20 @@ impl Model {
         self
     }
 
+    pub fn replace_mesh(&mut self, mut mesh: Mesh, platform: &Vector3<Milimeters>) {
+        // Apply the current transformations to the new mesh before replacing
+        mesh.set_position_unchecked(self.mesh.position());
+        mesh.set_scale_unchecked(self.mesh.scale());
+        mesh.set_rotation_unchecked(self.mesh.rotation());
+        mesh.update_transformation_matrix();
+        self.mesh = mesh;
+
+        // Invalidate buffers so they will be recreated
+        self.buffers = None;
+
+        self.update_oob(platform);
+    }
+
     pub fn randomize_color(&mut self) -> &mut Self {
         let shift = rand::random::<f32>() * TAU;
         self.color = START_COLOR.hue_shift(shift).to_linear_srgb();

--- a/mslicer/src/app/project/model.rs
+++ b/mslicer/src/app/project/model.rs
@@ -37,6 +37,7 @@ pub struct Model {
     pub exposure: u8,
     pub hidden: bool,
     pub ui: ModelUi,
+    pub parent_model_id: Option<u32>,
 
     buffers: Option<RenderedMeshBuffers>,
 }
@@ -86,6 +87,7 @@ impl Model {
             exposure: 255,
             ui: ModelUi::default(),
 
+            parent_model_id: None,
             buffers: None,
         }
     }
@@ -117,6 +119,11 @@ impl Model {
 
     pub fn with_random_color(mut self) -> Self {
         self.randomize_color();
+        self
+    }
+
+    pub fn with_parent_model_id(mut self, parent_id: u32) -> Self {
+        self.parent_model_id = Some(parent_id);
         self
     }
 
@@ -208,6 +215,7 @@ impl Clone for Model {
 
             exposure: self.exposure,
 
+            parent_model_id: self.parent_model_id,
             buffers: None,
         }
     }

--- a/mslicer/src/app/project/model.rs
+++ b/mslicer/src/app/project/model.rs
@@ -1,5 +1,6 @@
 use std::{
     f32::consts::TAU,
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicU32, Ordering},
@@ -37,6 +38,7 @@ pub struct Model {
     pub exposure: u8,
     pub hidden: bool,
     pub ui: ModelUi,
+    pub file_path: Option<PathBuf>,
     pub parent_model_id: Option<u32>,
 
     buffers: Option<RenderedMeshBuffers>,
@@ -87,6 +89,7 @@ impl Model {
             exposure: 255,
             ui: ModelUi::default(),
 
+            file_path: None,
             parent_model_id: None,
             buffers: None,
         }
@@ -124,6 +127,11 @@ impl Model {
 
     pub fn with_parent_model_id(mut self, parent_id: u32) -> Self {
         self.parent_model_id = Some(parent_id);
+        self
+    }
+
+    pub fn with_file_path(mut self, file_path: PathBuf) -> Self {
+        self.file_path = Some(file_path);
         self
     }
 
@@ -215,6 +223,7 @@ impl Clone for Model {
 
             exposure: self.exposure,
 
+            file_path: self.file_path.clone(),
             parent_model_id: self.parent_model_id,
             buffers: None,
         }

--- a/mslicer/src/app/project/storage.rs
+++ b/mslicer/src/app/project/storage.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use anyhow::{Result, ensure};
 use nalgebra::Vector3;
@@ -39,6 +39,7 @@ struct ModelInfo {
     scale: Vector3<f32>,
     rotation: Vector3<f32>,
 
+    file_path: Option<PathBuf>,
     parent_model_id: Option<u32>,
 }
 
@@ -53,6 +54,7 @@ impl ModelInfo {
             position: model.mesh.position(),
             scale: model.mesh.scale(),
             rotation: model.mesh.rotation(),
+            file_path: model.file_path.clone(),
             parent_model_id: model.parent_model_id,
         }
     }
@@ -64,11 +66,15 @@ impl ModelInfo {
         mesh.set_rotation_unchecked(self.rotation);
         mesh.update_transformation_matrix();
 
-        Model::from_mesh(mesh)
+        let mut model = Model::from_mesh(mesh)
             .with_name(self.name)
             .with_color(self.color.into())
             .with_exposure(self.exposure)
-            .with_hidden(self.hidden)
+            .with_hidden(self.hidden);
+        if let Some(file_path) = self.file_path {
+            model = model.with_file_path(file_path);
+        }
+        model
     }
 
     pub fn serialize<T: Serializer>(&self, ser: &mut T) {
@@ -86,6 +92,14 @@ impl ModelInfo {
         self.position.serialize(ser);
         self.scale.serialize(ser);
         self.rotation.serialize(ser);
+
+        // File path
+        ser.write_bool(self.file_path.is_some());
+        if let Some(file_path) = &self.file_path {
+            let path_str = file_path.to_string_lossy();
+            ser.write_u32_be(path_str.len() as u32);
+            ser.write_bytes(path_str.as_bytes());
+        }
 
         // Parent model ID
         ser.write_bool(self.parent_model_id.is_some());
@@ -108,6 +122,17 @@ impl ModelInfo {
             position: Vector3::<f32>::deserialize(des),
             scale: Vector3::<f32>::deserialize(des),
             rotation: Vector3::<f32>::deserialize(des),
+            file_path: {
+                let has_path = des.read_bool();
+                if has_path {
+                    let path_len = des.read_u32_be();
+                    let path_data = des.read_bytes(path_len as usize);
+                    let path_str = String::from_utf8_lossy(&path_data);
+                    Some(PathBuf::from(&*path_str))
+                } else {
+                    None
+                }
+            },
             parent_model_id: {
                 let has_parent = des.read_bool();
                 if has_parent {

--- a/mslicer/src/app/project/storage.rs
+++ b/mslicer/src/app/project/storage.rs
@@ -38,6 +38,8 @@ struct ModelInfo {
     position: Vector3<f32>,
     scale: Vector3<f32>,
     rotation: Vector3<f32>,
+
+    parent_model_id: Option<u32>,
 }
 
 impl ModelInfo {
@@ -51,6 +53,7 @@ impl ModelInfo {
             position: model.mesh.position(),
             scale: model.mesh.scale(),
             rotation: model.mesh.rotation(),
+            parent_model_id: model.parent_model_id,
         }
     }
 
@@ -83,6 +86,12 @@ impl ModelInfo {
         self.position.serialize(ser);
         self.scale.serialize(ser);
         self.rotation.serialize(ser);
+
+        // Parent model ID
+        ser.write_bool(self.parent_model_id.is_some());
+        if let Some(parent_id) = self.parent_model_id {
+            ser.write_u32_be(parent_id);
+        }
     }
 
     pub fn deserialize<T: Deserializer>(des: &mut T, version: u16) -> Self {
@@ -99,6 +108,14 @@ impl ModelInfo {
             position: Vector3::<f32>::deserialize(des),
             scale: Vector3::<f32>::deserialize(des),
             rotation: Vector3::<f32>::deserialize(des),
+            parent_model_id: {
+                let has_parent = des.read_bool();
+                if has_parent {
+                    Some(des.read_u32_be())
+                } else {
+                    None
+                }
+            },
         }
     }
 }

--- a/mslicer/src/app/task/mesh_load.rs
+++ b/mslicer/src/app/task/mesh_load.rs
@@ -23,6 +23,7 @@ pub struct MeshLoad {
     join: TaskThread<mesh_format::Mesh>,
     name: String,
     file_path: Option<PathBuf>,
+    model_index: Option<usize>,
 }
 
 impl MeshLoad {
@@ -37,6 +38,7 @@ impl MeshLoad {
             progress,
             name,
             file_path: Some(path),
+            model_index: None,
         }
     }
 
@@ -50,6 +52,27 @@ impl MeshLoad {
             progress,
             name,
             file_path: None,
+            model_index: None,
+        }
+    }
+
+    pub fn reload(file_path: PathBuf, model_index: usize) -> Self {
+        let file = File::open(&file_path).unwrap();
+        let des = ReaderDeserializer::new(BufReader::new(file));
+        let progress = Progress::new();
+        Self {
+            join: TaskThread::spawn(clone!([progress, file_path], move || {
+                load_mesh(
+                    des,
+                    &file_path.extension().unwrap_or_default().to_string_lossy(),
+                    progress,
+                )
+                .unwrap()
+            })),
+            progress,
+            name: file_path.to_string_lossy().into_owned(),
+            file_path: Some(file_path),
+            model_index: Some(model_index),
         }
     }
 }
@@ -64,18 +87,31 @@ impl Task for MeshLoad {
                 mesh.face_count()
             );
 
-            let mut model = Model::from_mesh(mesh)
-                .with_name(mem::take(&mut self.name))
-                .with_random_color();
-            if let Some(file_path) = self.file_path.take() {
-                model = model.with_file_path(file_path);
+            if let Some(model_index) = self.model_index {
+                // Reload existing model
+                let model = &mut app.project.models[model_index];
+                model.replace_mesh(mesh, &app.project.slice_config.platform_size);
+
+                PollResult::complete()
+                    .with_task(MeshManifold::new(model))
+                    .with_task(BuildAccelerationStructures::new(model))
+            } else {
+                // Create new model
+                let mut model = Model::from_mesh(mesh)
+                    .with_name(mem::take(&mut self.name))
+                    .with_random_color();
+
+                if let Some(file_path) = self.file_path.take() {
+                    model = model.with_file_path(file_path);
+                }
+
+                model.update_oob(&app.project.slice_config.platform_size);
+                let result = PollResult::complete()
+                    .with_task(MeshManifold::new(&model))
+                    .with_task(BuildAccelerationStructures::new(&model));
+                app.project.models.push(model);
+                result
             }
-            model.update_oob(&app.project.slice_config.platform_size);
-            let result = PollResult::complete()
-                .with_task(MeshManifold::new(&model))
-                .with_task(BuildAccelerationStructures::new(&model));
-            app.project.models.push(model);
-            result
         })
     }
 

--- a/mslicer/src/app/task/mesh_load.rs
+++ b/mslicer/src/app/task/mesh_load.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::BufReader, mem};
+use std::{fs::File, io::BufReader, mem, path::PathBuf};
 
 use clone_macro::clone;
 use common::{
@@ -25,7 +25,8 @@ pub struct MeshLoad {
 }
 
 impl MeshLoad {
-    pub fn file(file: File, name: String, format: String) -> Self {
+    pub fn file(path: PathBuf, name: String, format: String) -> Self {
+        let file = File::open(&path).unwrap();
         let des = ReaderDeserializer::new(BufReader::new(file));
         let progress = Progress::new();
         Self {

--- a/mslicer/src/app/task/mesh_load.rs
+++ b/mslicer/src/app/task/mesh_load.rs
@@ -22,6 +22,7 @@ pub struct MeshLoad {
     progress: Progress,
     join: TaskThread<mesh_format::Mesh>,
     name: String,
+    file_path: Option<PathBuf>,
 }
 
 impl MeshLoad {
@@ -35,6 +36,7 @@ impl MeshLoad {
             })),
             progress,
             name,
+            file_path: Some(path),
         }
     }
 
@@ -47,6 +49,7 @@ impl MeshLoad {
             })),
             progress,
             name,
+            file_path: None,
         }
     }
 }
@@ -64,6 +67,9 @@ impl Task for MeshLoad {
             let mut model = Model::from_mesh(mesh)
                 .with_name(mem::take(&mut self.name))
                 .with_random_color();
+            if let Some(file_path) = self.file_path.take() {
+                model = model.with_file_path(file_path);
+            }
             model.update_oob(&app.project.slice_config.platform_size);
             let result = PollResult::complete()
                 .with_task(MeshManifold::new(&model))

--- a/mslicer/src/ui/drag_and_drop.rs
+++ b/mslicer/src/ui/drag_and_drop.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fs::File, path::Path};
+use std::{borrow::Cow, path::Path};
 
 use egui::{Align2, Color32, Context, FontFamily, FontId, Id, LayerId, Order, pos2};
 use egui_phosphor::regular::{FILE_TEXT, FILES};
@@ -25,8 +25,8 @@ pub fn update(app: &mut App, ctx: &Context) {
                 if format == "mslicer" {
                     app.tasks.add(ProjectLoad::new(path.to_path_buf()));
                 } else {
-                    let file = File::open(path).unwrap();
-                    app.tasks.add(MeshLoad::file(file, name, format.into()));
+                    app.tasks
+                        .add(MeshLoad::file(path.to_path_buf(), name, format.into()));
                 }
             }
         }

--- a/mslicer/src/windows/models.rs
+++ b/mslicer/src/windows/models.rs
@@ -295,3 +295,23 @@ fn rad_to_deg(pos: Vector3<f32>) -> Vector3<f32> {
 fn deg_to_rad(pos: Vector3<f32>) -> Vector3<f32> {
     pos.map(|x| x.to_radians())
 }
+
+/// Removes all support models for a given parent model ID.
+/// Returns a vector of indices that were removed.
+fn remove_supports_for_model(app: &mut App, model_id: u32) -> Vec<usize> {
+    let supports_to_remove: Vec<usize> = app
+        .project
+        .models
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.parent_model_id == Some(model_id))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    // Remove supports in reverse order to avoid index shifting
+    for idx in supports_to_remove.iter().rev() {
+        app.project.models.remove(*idx);
+    }
+
+    supports_to_remove
+}

--- a/mslicer/src/windows/models.rs
+++ b/mslicer/src/windows/models.rs
@@ -7,8 +7,8 @@ use egui::{
     UiBuilder, Widget, vec2,
 };
 use egui_phosphor::regular::{
-    ARROW_LINE_DOWN, COPY, CURSOR_TEXT, DICE_THREE, EYE, EYE_SLASH, LINK_BREAK, LINK_SIMPLE, TRASH,
-    WARNING,
+    ARROW_COUNTER_CLOCKWISE, ARROW_LINE_DOWN, COPY, CURSOR_TEXT, DICE_THREE, EYE, EYE_SLASH,
+    LINK_BREAK, LINK_SIMPLE, TRASH, WARNING,
 };
 use nalgebra::Vector3;
 
@@ -17,6 +17,7 @@ use crate::{
         App,
         history::ModelAction,
         project::model::{MeshWarnings, RenameState},
+        task::MeshLoad,
     },
     ui::components::{
         being_edited, grid, history_tracked_model, vec3_dragger, vec3_dragger_proportional,
@@ -31,6 +32,7 @@ enum Action {
     None,
     Remove(usize),
     Duplicate(usize),
+    Reload(usize),
 }
 
 pub fn ui(app: &mut App, ui: &mut Ui, ctx: &Context) {
@@ -102,6 +104,24 @@ pub fn ui(app: &mut App, ui: &mut Ui, ctx: &Context) {
                 let model = app.project.models[i].clone();
                 app.project.models.push(model);
             }
+            Action::Reload(i) => {
+                if let Some(file_path) = app.project.models[i].file_path.clone() {
+                    let model_id = app.project.models[i].id;
+                    let supports_removed = remove_supports_for_model(app, model_id);
+
+                    if !supports_removed.is_empty() {
+                        // Show warning to user
+                        use crate::ui::popup::PopupIcon;
+                        app.popup.open(crate::ui::popup::Popup::simple(
+                            "Supports Removed",
+                            PopupIcon::Warning,
+                            "Supports were removed due to model reload. Please regenerate supports if needed."
+                        ));
+                    }
+
+                    app.tasks.add(MeshLoad::reload(file_path, i));
+                }
+            }
             Action::None => {}
         }
     }
@@ -167,6 +187,11 @@ fn model_properties(app: &mut App, ui: &mut Ui, ctx: &Context, action: &mut Acti
     ui.horizontal_wrapped(|ui| {
         (ui.button(concatcp!(CURSOR_TEXT, " Rename")).clicked())
             .then(|| model.ui.rename = RenameState::Starting);
+        if model.file_path.is_some() {
+            (ui.button(concatcp!(ARROW_COUNTER_CLOCKWISE, " Reload"))
+                .clicked())
+            .then(|| *action = Action::Reload(i));
+        }
         (ui.button(concatcp!(TRASH, " Delete")).clicked()).then(|| *action = Action::Remove(i));
         (ui.button(concatcp!(COPY, " Duplicate")).clicked())
             .then(|| *action = Action::Duplicate(i));

--- a/mslicer/src/windows/supports.rs
+++ b/mslicer/src/windows/supports.rs
@@ -152,7 +152,8 @@ fn generate_support(
     let (supports, debug) = support.generate_line_supports(&mesh.mesh, half_edge);
     let mesh = Model::from_mesh(supports)
         .with_name(format!("Supports {}", mesh.name))
-        .with_random_color();
+        .with_random_color()
+        .with_parent_model_id(mesh.id);
 
     meshes.push(mesh);
     debug

--- a/mslicer/src/windows/top_bar.rs
+++ b/mslicer/src/windows/top_bar.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-
 use const_format::concatcp;
 use egui::{
     Button, Context, Key, KeyboardShortcut, Modifiers, TopBottomPanel, Ui, ViewportCommand,
@@ -154,8 +152,11 @@ fn import_model(app: &mut App) {
             let ext = path.extension();
             let format = ext.unwrap_or_default().to_string_lossy();
 
-            let file = File::open(path).unwrap();
-            tasks.push(Box::new(MeshLoad::file(file, name, format.into())));
+            tasks.push(Box::new(MeshLoad::file(
+                path.to_path_buf(),
+                name,
+                format.into(),
+            )));
         },
     ));
 }


### PR DESCRIPTION
This is very useful when you're iterating on a model and don't want to keep going through the delete->load->reposition loop.

It was not as straightforward as I expected, so I've split it into several atomic commits to make it easier to review.

I'm not particularly happy with how supports track their parent model, but a cleaner implementation would likely need some deeper changes (maybe to the `Project` struct, where models are currently held in a `Vec<Models>`). I'm definitely open to suggestions.